### PR TITLE
fix: CollectionManagerConstructor

### DIFF
--- a/scripts/migrate/constructors/impl/CollectionManagerConstructorFactory.ts
+++ b/scripts/migrate/constructors/impl/CollectionManagerConstructorFactory.ts
@@ -27,7 +27,7 @@ export class CollectionManagerConstructorFactory extends ConstructorFactory {
       getAddress(ContractName.MANAToken),
       getAddress(ContractName.Committee),
       owner,
-      getAddress(ContractName.Rarities),
+      getAddress(ContractName.RaritiesWithOracle),
       [RESCUE_ITEMS_SELECTOR, SET_APPROVE_COLLECTION_SELECTOR, SET_EDITABLE_SELECTOR],
       [true, true, true]
     ];


### PR DESCRIPTION
This PR fixes the `CollectionManager` constructor, it was using the `Rarities` collection address instead of the `RaritiesWithOracle` collection address.